### PR TITLE
BusExtensions and package dependencies constraints

### DIFF
--- a/src/Core/BusExtensions.cs
+++ b/src/Core/BusExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nybus
+{
+    public static class BusExtensions
+    {
+        public static async Task InvokeManyCommands<TCommand>(this IBus bus, IEnumerable<TCommand> commands)
+            where TCommand : class, ICommand
+        {
+            if (bus == null)
+            {
+                throw new ArgumentNullException(nameof(bus));
+            }
+
+            if (commands == null) return;
+
+            await Task.WhenAll(commands.Select(bus.InvokeCommand)).ConfigureAwait(false);
+        }
+
+        public static async Task RaiseManyEvents<TEvent>(this IBus bus, IEnumerable<TEvent> events)
+            where TEvent : class, IEvent
+        {
+            if (bus == null)
+            {
+                throw new ArgumentNullException(nameof(bus));
+            }
+
+            if (events == null) return;
+
+            await Task.WhenAll(events.Select(bus.RaiseEvent)).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BusExtensions.cs" />
     <Compile Include="Configuration\DelegateCommandHandler.cs" />
     <Compile Include="Configuration\DelegateEventHandler.cs" />
     <Compile Include="Configuration\IBusBuilder.cs" />

--- a/src/MassTransit/MassTransit.nuspec
+++ b/src/MassTransit/MassTransit.nuspec
@@ -12,8 +12,8 @@
         <description>Nybus bus based on MassTransit</description>
         <language>en-US</language>
         <dependencies>
-            <dependency id="MassTransit" version="2.10.1" />
-            <dependency id="MassTransit.RabbitMQ" version="2.10.1" />
+            <dependency id="MassTransit" version="[2,3)" />
+            <dependency id="MassTransit.RabbitMQ" version="[2,3)" />
         </dependencies>
     </metadata>
 </package>

--- a/src/NLog/NLog.nuspec
+++ b/src/NLog/NLog.nuspec
@@ -12,7 +12,7 @@
     <description>NLog support for Nybus</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="NLog.Config" version="4.1.1" />
+      <dependency id="NLog.Config" version="[4.1,5)" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Rx/Rx.nuspec
+++ b/src/Rx/Rx.nuspec
@@ -12,7 +12,7 @@
         <description>Rx support for Nybus.</description>
         <language>en-US</language>
         <dependencies>
-            <dependency id="Rx-Linq" version="2.2.5" />
+            <dependency id="Rx-Linq" version="[2.2,3)" />
         </dependencies>
     </metadata>
 </package>

--- a/tests/Tests.Core/BusExtensionsTests.cs
+++ b/tests/Tests.Core/BusExtensionsTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Nybus;
+using Ploeh.AutoFixture;
+// ReSharper disable InvokeAsExtensionMethod
+
+namespace Tests
+{
+    [TestFixture]
+    public class BusExtensionsTests
+    {
+        private IFixture fixture;
+        private Mock<IBus> mockBus;
+
+        [SetUp]
+        public void Initialize()
+        {
+            fixture = new Fixture();
+
+            mockBus = new Mock<IBus>();
+        }
+
+        [Test]
+        public async Task InvokeManyCommands_forwards_to_IBus()
+        {
+            var commands = fixture.CreateMany<TestCommand>().ToArray();
+
+            await BusExtensions.InvokeManyCommands(mockBus.Object, commands);
+
+            mockBus.Verify(p => p.InvokeCommand(It.IsAny<TestCommand>()), Times.Exactly(commands.Length));
+        }
+
+        [Test, ExpectedException]
+        public async Task InvokeManyCommands_Bus_is_required()
+        {
+            var commands = fixture.CreateMany<TestCommand>().ToArray();
+
+            await BusExtensions.InvokeManyCommands(null, commands);
+        }
+
+        [Test]
+        public async Task InvokeManyCommands_no_exception_if_commands_is_null()
+        {
+            IEnumerable<TestCommand> commands = null;
+
+            await BusExtensions.InvokeManyCommands(mockBus.Object, commands);
+
+            mockBus.Verify(p => p.InvokeCommand(It.IsAny<TestCommand>()), Times.Never);
+
+        }
+
+        [Test]
+        public async Task RaiseManyEvents_forwards_to_IBus()
+        {
+            var events = fixture.CreateMany<TestEvent>().ToArray();
+
+            await BusExtensions.RaiseManyEvents(mockBus.Object, events);
+
+            mockBus.Verify(p => p.RaiseEvent(It.IsAny<TestEvent>()), Times.Exactly(events.Length));
+        }
+
+        [Test, ExpectedException]
+        public async Task RaiseManyEvents_Bus_is_required()
+        {
+            var events = fixture.CreateMany<TestEvent>().ToArray();
+
+            await BusExtensions.RaiseManyEvents(null, events);
+        }
+
+        [Test]
+        public async Task RaiseManyEvents_no_exception_if_commands_is_null()
+        {
+            IEnumerable<TestEvent> events = null;
+
+            await BusExtensions.RaiseManyEvents(mockBus.Object, events);
+
+            mockBus.Verify(p => p.RaiseEvent(It.IsAny<TestEvent>()), Times.Never);
+
+        }
+
+    }
+}

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BusExtensionsTests.cs" />
     <Compile Include="Configuration\DefaultCommandContextFactoryTests.cs" />
     <Compile Include="Configuration\DefaultCommandMessageFactoryTests.cs" />
     <Compile Include="Configuration\DefaultEventContextFactoryTests.cs" />


### PR DESCRIPTION
Core
- Added BusExtensions
  - InvokeManyCommands
  - RaiseManyEvents

MassTransit
- MassTransit packages now are locked on 2.*

NLog
- NLog packages now are locked on package version > 4.1 and < 5

Rx
- Rx packages now are locked on package version > 2.2 and < 3
