### PR TITLE
#11 Fixed issue with SystemClock

### DIFF
--- a/src/Interfaces/Utils/IClock.cs
+++ b/src/Interfaces/Utils/IClock.cs
@@ -18,6 +18,6 @@ namespace Nybus.Utils
 
     public class SystemClock : IClock
     {
-        public DateTimeOffset Now { get; } = DateTimeOffset.Now;
+        public DateTimeOffset Now => DateTimeOffset.Now;
     }
 }


### PR DESCRIPTION
SystemClock now returns DateTimeOffset.Now result rather that storying it in a backing field. Changed from getter-only auto-property to expression-bodied property.
