### PR TITLE
Add generic check to handler registration

### DIFF
--- a/src/Nybus.Abstractions/ICommand.cs
+++ b/src/Nybus.Abstractions/ICommand.cs
@@ -7,7 +7,9 @@ namespace Nybus
 
     public interface ICommand { }
 
-    public interface ICommandHandler<TCommand> where TCommand : class, ICommand
+    public interface ICommandHandler { }
+
+    public interface ICommandHandler<TCommand> : ICommandHandler where TCommand : class, ICommand
     {
         Task HandleAsync(IDispatcher dispatcher, ICommandContext<TCommand> context);
     }

--- a/src/Nybus.Abstractions/IEvent.cs
+++ b/src/Nybus.Abstractions/IEvent.cs
@@ -7,7 +7,9 @@ namespace Nybus
 {
     public interface IEvent { }
 
-    public interface IEventHandler<TEvent> where TEvent : class, IEvent
+    public interface IEventHandler { }
+
+    public interface IEventHandler<TEvent> : IEventHandler where TEvent : class, IEvent
     {
         Task HandleAsync(IDispatcher dispatcher, IEventContext<TEvent> context);
     }

--- a/src/Nybus/ServiceCollectionExtensions.cs
+++ b/src/Nybus/ServiceCollectionExtensions.cs
@@ -82,9 +82,10 @@ namespace Nybus
             return services.AddTransient<ICommandHandler<TCommand>, THandler>();
         }
 
-        public static IServiceCollection AddCommandHandler<T>(this IServiceCollection services)
+        public static IServiceCollection AddCommandHandler<THandler>(this IServiceCollection services)
+            where THandler : class, ICommandHandler
         {
-            return AddCommandHandler(services, typeof(T));
+            return AddCommandHandler(services, typeof(THandler));
         }
 
         public static IServiceCollection AddCommandHandler(this IServiceCollection services, Type handlerType)
@@ -110,9 +111,10 @@ namespace Nybus
             return services.AddTransient<IEventHandler<TEvent>, THandler>();
         }
 
-        public static IServiceCollection AddEventHandler<T>(this IServiceCollection services)
+        public static IServiceCollection AddEventHandler<THandler>(this IServiceCollection services)
+            where THandler : class, IEventHandler
         {
-            return AddEventHandler(services, typeof(T));
+            return AddEventHandler(services, typeof(THandler));
         }
 
         public static IServiceCollection AddEventHandler(this IServiceCollection services, Type handlerType)


### PR DESCRIPTION
Adds `ICommandHandler` and `IEventHandler` interfaces

`ICommandHandler<TCommand>` now extends `ICommandHandler`
`IEventHandler<TEvent>` now extends `IEventHandler`

Adds the generic check to the extension methods
- `ServiceCollection.AddCommandHandler<THandler>`
- `ServiceCollection.AddEventHandler<THandler>`