### PR TITLE
RabbitMq: Configure has now additive effects

### DIFF
--- a/src/engines/Nybus.Engine.RabbitMq/Configuration/IRabbitMqConfigurator.cs
+++ b/src/engines/Nybus.Engine.RabbitMq/Configuration/IRabbitMqConfigurator.cs
@@ -34,11 +34,16 @@ namespace Nybus.Configuration
             }
         }
 
-        private Action<IRabbitMqConfiguration> _configurationAction;
+        private readonly List<Action<IRabbitMqConfiguration>> _configurationActions = new List<Action<IRabbitMqConfiguration>>();
 
         public void Configure(Action<IRabbitMqConfiguration> configure)
         {
-            _configurationAction = configure ?? throw new ArgumentNullException(nameof(configure));
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            _configurationActions.Add(configure);
         }
 
         private string _configurationSectionName;
@@ -67,7 +72,10 @@ namespace Nybus.Configuration
 
                 var configuration = factory.Create(op);
 
-                _configurationAction?.Invoke(configuration);
+                foreach (var configurationAction in _configurationActions)
+                {
+                    configurationAction?.Invoke(configuration);
+                }
 
                 return configuration;
             }));

--- a/tests/Tests.Nybus.Engine.RabbitMq/Configuration/RabbitMqConfiguratorTests.cs
+++ b/tests/Tests.Nybus.Engine.RabbitMq/Configuration/RabbitMqConfiguratorTests.cs
@@ -31,12 +31,11 @@ namespace Tests.Configuration
         }
 
         [Test, CustomAutoMoqData]
-        public void RegisterQueueFactoryProvider_adds_provider_with_custom_setup(RabbitMqConfigurator sut, TestNybusConfigurator configurator, TestQueueFactoryProvider factoryProvider)
+        public void RegisterQueueFactoryProvider_adds_provider_with_custom_setup(RabbitMqConfigurator sut, TestNybusConfigurator configurator, TestQueueFactoryProvider factoryProvider, Func<IServiceProvider, IQueueFactoryProvider> setup)
         {
-            var setup = new Mock<Func<IServiceProvider, IQueueFactoryProvider>>();
-            setup.Setup(p => p(It.IsAny<IServiceProvider>())).Returns(factoryProvider);
+            Mock.Get(setup).Setup(p => p(It.IsAny<IServiceProvider>())).Returns(factoryProvider);
 
-            sut.RegisterQueueFactoryProvider<TestQueueFactoryProvider>(setup.Object);
+            sut.RegisterQueueFactoryProvider<TestQueueFactoryProvider>(setup);
 
             sut.Apply(configurator);
 
@@ -48,17 +47,14 @@ namespace Tests.Configuration
 
             var provider = serviceProvider.GetService<IQueueFactoryProvider>();
 
-            setup.Verify(s => s(It.IsAny<IServiceProvider>()), Times.Once);
+            Mock.Get(setup).Verify(s => s(It.IsAny<IServiceProvider>()), Times.Once);
             Assert.That(provider, Is.SameAs(factoryProvider));
         }
 
         [Test, CustomAutoMoqData]
-        public void Configure_sets_action_to_be_used(RabbitMqConfigurator sut, TestNybusConfigurator configurator, IConfigurationFactory configurationFactory, RabbitMqOptions options)
+        public void Configure_sets_action_to_be_used(RabbitMqConfigurator sut, TestNybusConfigurator configurator, IConfigurationFactory configurationFactory, RabbitMqOptions options, Action<IRabbitMqConfiguration> configurationSetup)
         {
-            var configurationSetup = new Mock<Action<IRabbitMqConfiguration>>();
-            configurationSetup.Setup(p => p(It.IsAny<IRabbitMqConfiguration>()));
-
-            sut.Configure(configurationSetup.Object);
+            sut.Configure(configurationSetup);
 
             sut.Apply(configurator);
 
@@ -72,7 +68,33 @@ namespace Tests.Configuration
 
             var configuration = serviceProvider.GetService<IRabbitMqConfiguration>();
 
-            configurationSetup.Verify(p => p(configuration), Times.Once);
+            Mock.Get(configurationSetup).Verify(p => p(configuration), Times.Once);
+        }
+
+        [Test, CustomAutoMoqData]
+        public void Configure_usages_are_additive(RabbitMqConfigurator sut, TestNybusConfigurator configurator, IConfigurationFactory configurationFactory, RabbitMqOptions options, Action<IRabbitMqConfiguration>[] configurationSetupActions)
+        {
+            foreach (var configurationSetup in configurationSetupActions)
+            {
+                sut.Configure(configurationSetup);
+            }
+
+            sut.Apply(configurator);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configurationFactory);
+            services.AddSingleton(options);
+
+            configurator.ApplyServiceConfigurations(services);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var configuration = serviceProvider.GetService<IRabbitMqConfiguration>();
+
+            foreach (var configurationSetup in configurationSetupActions)
+            {
+                Mock.Get(configurationSetup).Verify(p => p(configuration), Times.Once);
+            }
         }
 
         [Test, CustomAutoMoqData]


### PR DESCRIPTION
While configuring RabbitMq, invoking Configure multiple times has additive effects